### PR TITLE
Implement parameterized query

### DIFF
--- a/lib/req_athena.ex
+++ b/lib/req_athena.ex
@@ -62,11 +62,6 @@ defmodule ReqAthena do
     |> Base.encode16()
   end
 
-  defp put_execute_statement_query(name, params) do
-    params = for param <- params, do: encode_value(param)
-    "EXECUTE #{name} USING #{Enum.join(params, ", ")}"
-  end
-
   defp handle_athena_result({request, %{status: 200} = response}) do
     action = Request.get_private(request, :athena_action)
     parameterized? = Request.get_private(request, :athena_parameterized?, false)
@@ -121,7 +116,7 @@ defmodule ReqAthena do
   defp execute_prepared_query(request) do
     {query, params} = request.options.athena
     statement_name = :erlang.md5(query) |> Base.encode16()
-    athena = put_execute_statement_query(statement_name, params)
+    athena = "EXECUTE #{statement_name} USING " <> Enum.map_join(params, ", ", &encode_value/1)
 
     {Request.halt(request), Req.post!(%{request | private: %{}}, athena: athena)}
   end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -481,7 +481,8 @@ defmodule IntegrationTest do
     # query single row from planet table
     assert query_response =
              Req.post!(req,
-               athena: {"SELECT * FROM planet WHERE id = ? and type = ?", [239_970_142, "node"]}
+               athena:
+                 {"SELECT id, type FROM planet WHERE id = ? and type = ?", [239_970_142, "node"]}
              )
 
     assert query_response.status == 200
@@ -512,173 +513,19 @@ defmodule IntegrationTest do
                    "SchemaName" => "",
                    "TableName" => "",
                    "Type" => "varchar"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "tags",
-                   "Name" => "tags",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 0,
-                   "Scale" => 0,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "map"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "lat",
-                   "Name" => "lat",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 9,
-                   "Scale" => 7,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "decimal"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "lon",
-                   "Name" => "lon",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 10,
-                   "Scale" => 7,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "decimal"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "nds",
-                   "Name" => "nds",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 0,
-                   "Scale" => 0,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "array"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "members",
-                   "Name" => "members",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 0,
-                   "Scale" => 0,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "array"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "changeset",
-                   "Name" => "changeset",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 19,
-                   "Scale" => 0,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "bigint"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "timestamp",
-                   "Name" => "timestamp",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 3,
-                   "Scale" => 0,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "timestamp"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "uid",
-                   "Name" => "uid",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 19,
-                   "Scale" => 0,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "bigint"
-                 },
-                 %{
-                   "CaseSensitive" => true,
-                   "CatalogName" => "hive",
-                   "Label" => "user",
-                   "Name" => "user",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 2_147_483_647,
-                   "Scale" => 0,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "varchar"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "version",
-                   "Name" => "version",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 19,
-                   "Scale" => 0,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "bigint"
-                 },
-                 %{
-                   "CaseSensitive" => false,
-                   "CatalogName" => "hive",
-                   "Label" => "visible",
-                   "Name" => "visible",
-                   "Nullable" => "UNKNOWN",
-                   "Precision" => 0,
-                   "Scale" => 0,
-                   "SchemaName" => "",
-                   "TableName" => "",
-                   "Type" => "boolean"
                  }
                ],
                "ResultRows" => [
                  %{
                    "Data" => [
                      "id",
-                     "type",
-                     "tags",
-                     "lat",
-                     "lon",
-                     "nds",
-                     "members",
-                     "changeset",
-                     "timestamp",
-                     "uid",
-                     "user",
-                     "version",
-                     "visible"
+                     "type"
                    ]
                  },
                  %{
                    "Data" => [
                      "239970142",
-                     "node",
-                     "{created_by=JOSM}",
-                     "-2.1627500",
-                     "139.3920000",
-                     "[]",
-                     "[]",
-                     "665284",
-                     "2008-01-19 15:43:38.000",
-                     "7744",
-                     "Keith Thomson",
-                     "1",
-                     "true"
+                     "node"
                    ]
                  }
                ],
@@ -707,138 +554,6 @@ defmodule IntegrationTest do
                      "SchemaName" => "",
                      "TableName" => "",
                      "Type" => "varchar"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "tags",
-                     "Name" => "tags",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 0,
-                     "Scale" => 0,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "map"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "lat",
-                     "Name" => "lat",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 9,
-                     "Scale" => 7,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "decimal"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "lon",
-                     "Name" => "lon",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 10,
-                     "Scale" => 7,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "decimal"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "nds",
-                     "Name" => "nds",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 0,
-                     "Scale" => 0,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "array"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "members",
-                     "Name" => "members",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 0,
-                     "Scale" => 0,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "array"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "changeset",
-                     "Name" => "changeset",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 19,
-                     "Scale" => 0,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "bigint"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "timestamp",
-                     "Name" => "timestamp",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 3,
-                     "Scale" => 0,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "timestamp"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "uid",
-                     "Name" => "uid",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 19,
-                     "Scale" => 0,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "bigint"
-                   },
-                   %{
-                     "CaseSensitive" => true,
-                     "CatalogName" => "hive",
-                     "Label" => "user",
-                     "Name" => "user",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 2_147_483_647,
-                     "Scale" => 0,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "varchar"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "version",
-                     "Name" => "version",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 19,
-                     "Scale" => 0,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "bigint"
-                   },
-                   %{
-                     "CaseSensitive" => false,
-                     "CatalogName" => "hive",
-                     "Label" => "visible",
-                     "Name" => "visible",
-                     "Nullable" => "UNKNOWN",
-                     "Precision" => 0,
-                     "Scale" => 0,
-                     "SchemaName" => "",
-                     "TableName" => "",
-                     "Type" => "boolean"
                    }
                  ]
                },
@@ -846,35 +561,13 @@ defmodule IntegrationTest do
                  %{
                    "Data" => [
                      %{"VarCharValue" => "id"},
-                     %{"VarCharValue" => "type"},
-                     %{"VarCharValue" => "tags"},
-                     %{"VarCharValue" => "lat"},
-                     %{"VarCharValue" => "lon"},
-                     %{"VarCharValue" => "nds"},
-                     %{"VarCharValue" => "members"},
-                     %{"VarCharValue" => "changeset"},
-                     %{"VarCharValue" => "timestamp"},
-                     %{"VarCharValue" => "uid"},
-                     %{"VarCharValue" => "user"},
-                     %{"VarCharValue" => "version"},
-                     %{"VarCharValue" => "visible"}
+                     %{"VarCharValue" => "type"}
                    ]
                  },
                  %{
                    "Data" => [
                      %{"VarCharValue" => "239970142"},
-                     %{"VarCharValue" => "node"},
-                     %{"VarCharValue" => "{created_by=JOSM}"},
-                     %{"VarCharValue" => "-2.1627500"},
-                     %{"VarCharValue" => "139.3920000"},
-                     %{"VarCharValue" => "[]"},
-                     %{"VarCharValue" => "[]"},
-                     %{"VarCharValue" => "665284"},
-                     %{"VarCharValue" => "2008-01-19 15:43:38.000"},
-                     %{"VarCharValue" => "7744"},
-                     %{"VarCharValue" => "Keith Thomson"},
-                     %{"VarCharValue" => "1"},
-                     %{"VarCharValue" => "true"}
+                     %{"VarCharValue" => "node"}
                    ]
                  }
                ]


### PR DESCRIPTION
- Closes #5 

This PR i'm not so happy on how we need to do to run parameterized queries... Basing on [AWS Athena docs](https://aws.amazon.com/pt/about-aws/whats-new/2021/07/amazon-athena-adds-parameterized-queries-to-improve-reusability-and-security/), we need to make 2 queries:

1) PREPARE statement:

```sql
PREPARE my_unique_statement_name FROM
SELECT * FROM planet WHERE id = ? AND type = ?
```

2) EXECUTE statement:

```sql
EXECUTE my_unique_statement_name USING 239970142, 'node'
```

And it'll return:

![Screenshot_20220602_165415](https://user-images.githubusercontent.com/6402997/171726797-3bf7ab08-4d0e-42d1-8e7e-8457e885d600.png)
