### PR TITLE
Add `:force_new_result` option to avoid cached results from AWS Athena

### DIFF
--- a/lib/req_athena.ex
+++ b/lib/req_athena.ex
@@ -18,6 +18,7 @@ defmodule ReqAthena do
     database
     athena
     output_location
+    force_new_result
   )a
 
   defguardp is_empty(value) when value in [nil, ""]
@@ -40,6 +41,8 @@ defmodule ReqAthena do
     * `:output_location` - Conditional. The S3 url location to output AWS Athena query results.
 
     * `:workgroup` - Conditional. The AWS Athena workgroup.
+
+    * `:force_new_result` - Optional. Forces a non-cached result from AWS Athena.
 
     * `:athena` - Required. The query to execute. It can be a plain sql string or
       a `{query, params}` tuple, where `query` can contain `?` placeholders and `params`
@@ -109,30 +112,36 @@ defmodule ReqAthena do
 
   defp run(%Request{options: %{athena: query} = options} = request) do
     url = "https://athena.#{options.region}.amazonaws.com"
+    force_new_result = options[:force_new_result] || false
 
     %{request | url: URI.parse(url)}
-    |> put_request_body(query)
+    |> put_request_body(query, force_new_result)
     |> sign_request("StartQueryExecution")
     |> Request.append_response_steps(athena_result: &handle_athena_result/1)
   end
 
   defp run(request), do: request
 
-  defp put_request_body(request, {query, []}) do
-    put_request_body(request, query)
+  defp put_request_body(request, {query, []}, force_new_result) do
+    put_request_body(request, query, force_new_result)
   end
 
-  defp put_request_body(request, {query, _params}) do
-    hash = :erlang.md5(query) |> Base.encode16()
+  defp put_request_body(request, {query, _params}, force_new_result) do
+    hash =
+      if force_new_result,
+        do: :os.system_time() |> to_string(),
+        else: :erlang.md5(query) |> Base.encode16()
+
     statement_name = "query_" <> hash
 
     request
-    |> put_request_body("PREPARE #{statement_name} FROM #{query}")
+    |> put_request_body("PREPARE #{statement_name} FROM #{query}", force_new_result)
     |> Request.put_private(:athena_parameterized?, true)
     |> Request.put_private(:athena_statement_name, statement_name)
   end
 
-  defp put_request_body(%{options: options} = request, query) when is_binary(query) do
+  defp put_request_body(%{options: options} = request, query, force_new_result)
+       when is_binary(query) do
     output_config =
       case {options[:output_location], options[:workgroup]} do
         {output, workgroup} when is_empty(output) and is_empty(workgroup) ->
@@ -154,14 +163,21 @@ defmodule ReqAthena do
         QueryString: query
       })
 
-    client_request_token = generate_client_request_token(body)
+    client_request_token = generate_client_request_token(body, force_new_result)
     body = Map.put(body, :ClientRequestToken, client_request_token)
 
     %{request | body: Jason.encode!(body)}
   end
 
-  defp generate_client_request_token(parameters) do
-    :erlang.md5(:erlang.term_to_binary(parameters))
+  defp generate_client_request_token(parameters, force_new_result) do
+    parameters =
+      if force_new_result,
+        do: Map.put(parameters, :SystemTime, :os.system_time()),
+        else: parameters
+
+    parameters
+    |> :erlang.term_to_binary()
+    |> :erlang.md5()
     |> Base.encode16()
   end
 


### PR DESCRIPTION
- Closes #20 