### PR TITLE
Fix v0.2.0 changelog date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.2.0](https://github.com/livebook-dev/req_athena/tree/v0.2.0) (2023-09-13)
+## [v0.2.0](https://github.com/livebook-dev/req_athena/tree/v0.2.0) (2024-09-13)
 
 ### Changed
 


### PR DESCRIPTION
A small thing I noticed: v0.2.0 was released in 2024, not 2023.