### PR TITLE
Use put_aws_sigv4 for computing signature

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,6 @@ defmodule ReqAthena.MixProject do
     [
       {:req, "~> 0.5.0"},
       {:req_s3, "~> 0.2"},
-      {:aws_signature, "~> 0.3.0"},
       {:aws_credentials, "~> 0.2", optional: true},
       {:explorer, "~> 0.9", optional: true},
       {:tzdata, "~> 1.1.1", only: :test},


### PR DESCRIPTION
There was a TODO and Req now comes with `put_aws_sigv4`, so I made the change.

Note that explorer depends on `aws_signature`, but it's optional dependency. Also, the code is simpler, so it's good either way.