### PR TITLE
Support location output parsed as CSV

### DIFF
--- a/lib/req_athena/s3.ex
+++ b/lib/req_athena/s3.ex
@@ -8,6 +8,7 @@ defmodule ReqAthena.S3 do
     manifest_csv_location = output_location <> "-manifest.csv"
 
     req_s3
+    |> Req.merge(decode_body: false)
     |> get_body(manifest_csv_location)
     |> String.trim()
     |> String.split("\n")


### PR DESCRIPTION
Newer versions of Req will attempt to decode the body based on the path name if the content-type is `application/octet-stream`. Since this is being hardcoded to `*-manifest.csv`, that means it will be decoded and fail the `String` function calls that were previously used in `ReqAthena.S3.get_locations/2`.

This forces `decode_body: false` for this specific request since it is expected to only be a newline delineated string

```
** (FunctionClauseError) no function clause matching in String.trim/1    
    
    The following arguments were given to String.trim/1:
    
        # 1
        [
          ["s3://aws-athena-query-results-123456789-us-east-1/livebook-2025-11-11T23:22:22.360496Z/results/20251111_232223_00039_nn6z5_2c4ed47b-ac2b-49f2-bb95-09b610cad7e6"],
          ["s3://aws-athena-query-results-123456789-us-east-1/livebook-2025-11-11T23:22:22.360496Z/results/20251111_232223_00039_nn6z5_bc04f78f-c397-4cf8-a2f0-cc51a6b20337"]
        ]
    
    Attempted function clauses (showing 1 out of 1):
    
        def trim(string) when is_binary(string)
    
    (elixir 1.18.4) lib/string.ex:1321: String.trim/1
    (req_athena 0.3.0) lib/req_athena/s3.ex:12: ReqAthena.S3.get_locations/2
    (req_athena 0.3.0) lib/req_athena.ex:402: ReqAthena.fetch_and_build_dataframe/3
    (req_athena 0.3.0) lib/req_athena.ex:387: ReqAthena.get_explorer_result/2
    (req 0.5.16) lib/req/request.ex:1135: anonymous fn/2 in Req.Request.run_response/2
    (elixir 1.18.4) lib/enum.ex:4968: Enumerable.List.reduce/3
    (elixir 1.18.4) lib/enum.ex:2600: Enum.reduce_while/3
    iex:2: (file)
```