### PR TITLE
Use returned `DataManifestLocation` if available

### DIFF
--- a/lib/req_athena.ex
+++ b/lib/req_athena.ex
@@ -351,12 +351,12 @@ defmodule ReqAthena do
   end
 
   defp get_json_result(request, response) do
-    output_location = Request.get_private(request, :athena_output_location)
+    manifest_location = Request.get_private(request, :athena_manifest_location)
 
     aws_credentials = aws_credentials_from_request(request)
     req_s3 = ReqAthena.S3.new(aws_credentials)
 
-    locations = ReqAthena.S3.get_locations(req_s3, output_location)
+    locations = ReqAthena.S3.get_locations(req_s3, manifest_location)
 
     # OPTIMIZE: use tasks to retrieve locations.
     results =
@@ -374,7 +374,7 @@ defmodule ReqAthena do
   end
 
   defp get_explorer_result(request, response) do
-    output_location = Request.get_private(request, :athena_output_location)
+    manifest_location = Request.get_private(request, :athena_manifest_location)
 
     aws_credentials = aws_credentials_from_request(request)
 
@@ -384,7 +384,7 @@ defmodule ReqAthena do
 
     decode_body = Req.Request.get_option(request, :decode_body, true)
 
-    result = fetcher_and_builder.(output_location, aws_credentials, decode_body)
+    result = fetcher_and_builder.(manifest_location, aws_credentials, decode_body)
 
     Request.halt(request, %{response | body: result})
   end
@@ -397,9 +397,9 @@ defmodule ReqAthena do
   end
 
   @doc false
-  def fetch_and_build_dataframe(output_location, aws_credentials, decode_body) do
+  def fetch_and_build_dataframe(manifest_location, aws_credentials, decode_body) do
     req_s3 = ReqAthena.S3.new(aws_credentials)
-    locations = ReqAthena.S3.get_locations(req_s3, output_location)
+    locations = ReqAthena.S3.get_locations(req_s3, manifest_location)
 
     if decode_body do
       build_lazy_frame(locations, aws_credentials)
@@ -456,13 +456,17 @@ defmodule ReqAthena do
         Request.halt(request, Req.post!(request))
 
       "SUCCEEDED" ->
+        output_location = body["QueryExecution"]["ResultConfiguration"]["OutputLocation"]
+
+        manifest_location =
+          body["QueryExecution"]["Statistics"]["DataManifestLocation"] ||
+            output_location <> "-manifest.csv"
+
         request =
           request
           |> prepare_action("GetQueryResults")
-          |> Request.put_private(
-            :athena_output_location,
-            body["QueryExecution"]["ResultConfiguration"]["OutputLocation"]
-          )
+          |> Request.put_private(:athena_output_location, output_location)
+          |> Request.put_private(:athena_manifest_location, manifest_location)
           |> Request.put_private(:athena_query_execution_id, query_execution_id)
 
         Request.halt(request, Req.post!(request))

--- a/lib/req_athena/s3.ex
+++ b/lib/req_athena/s3.ex
@@ -4,11 +4,9 @@ defmodule ReqAthena.S3 do
     options |> Req.new() |> ReqS3.attach(aws_sigv4: aws_credentials)
   end
 
-  def get_locations(req_s3, output_location) do
-    manifest_csv_location = output_location <> "-manifest.csv"
-
+  def get_locations(req_s3, manifest_location) do
     req_s3
-    |> get_body(manifest_csv_location)
+    |> get_body(manifest_location)
     |> String.trim()
     |> String.split("\n")
   end


### PR DESCRIPTION
Fixes #42

In some situations, the manifest file may be a slightly different path than what is set in `output_locations` (reasons not fully known). This would cause failures fetching the locations of results since the manifest would not exist due to the hardcoded path.

This changes to use the `DataManifestLocation` key if it is returned in the results rather than assuming the path.

<details><summary>Sample JSON response</summary>
<p>

```json
{
  "QueryExecution": {
    "EngineVersion": {
      "EffectiveEngineVersion": "Athena engine version 3",
      "SelectedEngineVersion": "Athena engine version 3"
    },
    "Query": "UNLOAD (SELECT count(*) FROM my_fav_table\n)\nTO 's3://aws-athena-query-results-123456789-us-east-1/livebook-2025-11-11T23:18:46.337381Z/results'\nWITH (format = 'PARQUET')",
    "QueryExecutionContext": { "Database": "my_fav_db" },
    "QueryExecutionId": "5b6d4bd6-d207-46a4-b1e3-84656c16ad5a",
    "ResultConfiguration": {
      "OutputLocation": "s3://aws-athena-query-results-123456789-us-east-1/livebook-2025-11-11T23:18:46.337381Z/5b6d4bd6-d207-46a4-b1e3-84656c16ad5a"
    },
    "ResultReuseConfiguration": {
      "ResultReuseByAgeConfiguration": { "Enabled": false }
    },
    "StatementType": "DML",
    "Statistics": {
      "DataManifestLocation": "s3://aws-athena-query-results-123456789-us-east-1/livebook-2025-11-11T23:18:46.337381Z/5b6d4bd6-d207-46a4-b1e3-84656c16ad5a-manifest.csv",
      "DataScannedInBytes": 212019779,
      "EngineExecutionTimeInMillis": 2903,
      "QueryPlanningTimeInMillis": 667,
      "QueryQueueTimeInMillis": 128,
      "ResultReuseInformation": { "ReusedPreviousResult": false },
      "ServicePreProcessingTimeInMillis": 74,
      "ServiceProcessingTimeInMillis": 43,
      "TotalExecutionTimeInMillis": 3148
    },
    "Status": {
      "CompletionDateTime": 1762903129.907,
      "State": "SUCCEEDED",
      "SubmissionDateTime": 1762903126.759
    },
    "SubstatementType": "UNLOAD",
    "WorkGroup": "primary"
  },
  "QueryExecutionDetail": {
    "OutputLocation": "s3://aws-athena-query-results-123456789-us-east-1/livebook-2025-11-11T23:18:46.337381Z/5b6d4bd6-d207-46a4-b1e3-84656c16ad5a",
    "Query": "UNLOAD (SELECT count(*) FROM my_fav_table\n)\nTO 's3://aws-athena-query-results-123456789-us-east-1/livebook-2025-11-11T23:18:46.337381Z/results'\nWITH (format = 'PARQUET')",
    "QueryExecutionContext": { "Database": "my_fav_db" },
    "QueryExecutionId": "5b6d4bd6-d207-46a4-b1e3-84656c16ad5a",
    "ResultConfiguration": {
      "OutputLocation": "s3://aws-athena-query-results-123456789-us-east-1/livebook-2025-11-11T23:18:46.337381Z/5b6d4bd6-d207-46a4-b1e3-84656c16ad5a"
    },
    "Stats": {
      "EngineExecutionTimeInMillis": 2903,
      "ProcessedBytes": 212019779,
      "ProcessedInputBytes": 2659877869,
      "ProcessedInputRows": 189833636,
      "ProcessedRows": 189833636,
      "ResultReuseInformation": { "ReusedPreviousResult": false }
    },
    "Status": {
      "CompletionDateTime": 1762903129.907,
      "State": "SUCCEEDED",
      "SubmissionDateTime": 1762903126.759
    },
    "WorkGroup": "primary"
  }
}
```

</p>
</details> 